### PR TITLE
Fix miui_install_success

### DIFF
--- a/Italian/main/MiuiPackageInstaller.apk/res/values-it/strings.xml
+++ b/Italian/main/MiuiPackageInstaller.apk/res/values-it/strings.xml
@@ -209,7 +209,7 @@ In alternativa, puoi disattivare la modalità Semplificata e riprovare."</string
   <string name="miui_install_fail_reason">Motivo</string>
   <string name="miui_install_source">Da \"%s\"</string>
   <string name="miui_install_source_unkown">Sconosciuto</string>
-  <string name="miui_install_success">Email installata</string>
+  <string name="miui_install_success">Applicazione installata</string>
   <string name="miui_install_version">Versione: %1$s | Dimensione: %2$s</string>
   <string name="miui_install_version_3">Versione: %1$s -&gt; %2$s | Dimensione: %3$s</string>
   <string name="miui_installing">Installazione...</string>


### PR DESCRIPTION
All'installazione di un APK viene visualizzato erroneamente il messaggio: Email installata, invece di Applicazione installata