### PR TITLE
Modifiche alle traduzioni dell'app Radio FM

### DIFF
--- a/Italian/main/MiRadio.apk/res/values-it/strings.xml
+++ b/Italian/main/MiRadio.apk/res/values-it/strings.xml
@@ -120,7 +120,7 @@
   <string name="apk_filter">Apk</string>
   <string name="app_downloads">%s download</string>
   <string name="app_label">Download</string>
-  <string name="app_name">Test Radio FM</string>
+  <string name="app_name">Radio FM</string>
   <string name="appbar_scrolling_view_behavior">com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior</string>
   <string name="artist_album">ALBUM</string>
   <string name="artist_area_all">Tutti</string>
@@ -1316,7 +1316,7 @@ Invia questo codice al supervisore."</string>
   <string name="usercenter_task_status_start">Avvia</string>
   <string name="usercenter_task_title">Missioni</string>
   <string name="using_recorder_cancel">Rifiuta</string>
-  <string name="using_recorder_confirm">Concorda e Scarica</string>
+  <string name="using_recorder_confirm">Accetta</string>
   <string name="using_recorder_dialog_message">"Radio ha bisogno di accedere ai servizi di registrazione del dispositivo per funzionare normalmente."</string>
   <string name="using_recorder_dialog_title">Permessi richiesti</string>
   <string name="v_code_title">Inserisci il codice di verifica</string>


### PR DESCRIPTION
- Cambiato titolo dell'app da Test "Radio FM" a "Radio FM"
- Cambiato test per Permessi Richiesti da "Concorda e Scarica" ad "Acccetta"